### PR TITLE
Item info blocks admin

### DIFF
--- a/src/view/adminhtml/layout/adminhtml_order_shipment_new.xml
+++ b/src/view/adminhtml/layout/adminhtml_order_shipment_new.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="order_item_extra_info">
+            <block name="additional.product.info.packs" template="Nanobots_ProductPack::sales/order/item/view/info.phtml">
+                <arguments>
+                    <argument name="viewModel" xsi:type="object">Nanobots\ProductPack\ViewModel\Product\Pack</argument>
+                </arguments>
+            </block>
+        </referenceBlock>
+    </body>
+</page>

--- a/src/view/adminhtml/layout/adminhtml_order_shipment_view.xml
+++ b/src/view/adminhtml/layout/adminhtml_order_shipment_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="order_item_extra_info">
+            <block name="additional.product.info.packs" template="Nanobots_ProductPack::sales/order/item/view/info.phtml">
+                <arguments>
+                    <argument name="viewModel" xsi:type="object">Nanobots\ProductPack\ViewModel\Product\Pack</argument>
+                </arguments>
+            </block>
+        </referenceBlock>
+    </body>
+</page>

--- a/src/view/adminhtml/layout/sales_order_creditmemo_new.xml
+++ b/src/view/adminhtml/layout/sales_order_creditmemo_new.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="order_item_extra_info">
+            <block name="additional.product.info.packs" template="Nanobots_ProductPack::sales/order/item/view/info.phtml">
+                <arguments>
+                    <argument name="viewModel" xsi:type="object">Nanobots\ProductPack\ViewModel\Product\Pack</argument>
+                </arguments>
+            </block>
+        </referenceBlock>
+    </body>
+</page>

--- a/src/view/adminhtml/layout/sales_order_creditmemo_view.xml
+++ b/src/view/adminhtml/layout/sales_order_creditmemo_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="order_item_extra_info">
+            <block name="additional.product.info.packs" template="Nanobots_ProductPack::sales/order/item/view/info.phtml">
+                <arguments>
+                    <argument name="viewModel" xsi:type="object">Nanobots\ProductPack\ViewModel\Product\Pack</argument>
+                </arguments>
+            </block>
+        </referenceBlock>
+    </body>
+</page>

--- a/src/view/adminhtml/layout/sales_order_invoice_new.xml
+++ b/src/view/adminhtml/layout/sales_order_invoice_new.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="order_item_extra_info">
+            <block name="additional.product.info.packs" template="Nanobots_ProductPack::sales/order/item/view/info.phtml">
+                <arguments>
+                    <argument name="viewModel" xsi:type="object">Nanobots\ProductPack\ViewModel\Product\Pack</argument>
+                </arguments>
+            </block>
+        </referenceBlock>
+    </body>
+</page>

--- a/src/view/adminhtml/layout/sales_order_invoice_view.xml
+++ b/src/view/adminhtml/layout/sales_order_invoice_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="order_item_extra_info">
+            <block name="additional.product.info.packs" template="Nanobots_ProductPack::sales/order/item/view/info.phtml">
+                <arguments>
+                    <argument name="viewModel" xsi:type="object">Nanobots\ProductPack\ViewModel\Product\Pack</argument>
+                </arguments>
+            </block>
+        </referenceBlock>
+    </body>
+</page>

--- a/src/view/adminhtml/layout/sales_order_view.xml
+++ b/src/view/adminhtml/layout/sales_order_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="order_item_extra_info">
+            <block name="additional.product.info.packs" template="Nanobots_ProductPack::sales/order/item/view/info.phtml">
+                <arguments>
+                    <argument name="viewModel" xsi:type="object">Nanobots\ProductPack\ViewModel\Product\Pack</argument>
+                </arguments>
+            </block>
+        </referenceBlock>
+    </body>
+</page>

--- a/src/view/adminhtml/templates/sales/order/item/view/info.phtml
+++ b/src/view/adminhtml/templates/sales/order/item/view/info.phtml
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright © Q-Solutions Studio: eCommerce Nanobots. All rights reserved.
+ *
+ * @category    Nanobots
+ * @package     Nanobots_ProductPack
+ * @author      Jakub Winkler <jwinkler@qsolutionsstudio.com>
+ * @author      Wojtek Wnuk <wojtek@qsolutionsstudio.com>
+ * @author      Łukasz Owczarczuk <lukasz@qsolutionsstudio.com>
+ */
+
+use Nanobots\ProductPack\Model\Product\Type\Pack as PackType;
+use Nanobots\ProductPack\ViewModel\Product\Pack;
+use Magento\Framework\View\Element\Template;
+use Magento\Quote\Model\Quote\Item;
+
+/** @var Template $block */
+/** @var Pack $viewModel */
+/** @var Item $item */
+$item = $block->getParentBlock()->getData('item');
+?>
+<?php if ($item->getProduct()->getTypeId() === PackType::TYPE_CODE): ?>
+    <?php
+        $viewModel = $block->getData('viewModel');
+        $buyRequest = $item->getBuyRequest();
+        $packOption = $buyRequest->getData('pack_option');
+
+        // check null param for multi cart data
+        if ($packOption === null) {
+            $itemOptions = $viewModel->getProductItemOptions((int)$item->getId());
+            foreach ($itemOptions as $itemOption) {
+                if ($itemOption->getCode() === "info_buyRequest") {
+                    $buyRequest = json_decode($itemOption->getValue(), true);
+                    if ($buyRequest) {
+                        $packOption = $buyRequest['pack_option'];
+                    }
+                }
+            }
+        }
+
+        $title = $packOption['title'] ?? '';
+        $qty = $packOption['pack_size'] ?? '';
+    ?>
+    <?php if ((int)$qty > 1): ?>
+<tr class="row-pack-options-container">
+    <td colspan="7">
+        <div class="pack-option-title">
+            <span><?= __('Package') ?>:&nbsp;<strong><?= __($title) ?></strong></span>
+        </div>
+        <div class="pack-option-qty">
+            <span><?= __('Units') ?>:&nbsp;</span><strong><?= $qty
+                ?></strong>
+        </div>
+    </td>
+</tr>
+    <?php endif ?>
+<?php endif; ?>

--- a/src/view/frontend/layout/sales_email_order_creditmemo_items.xml
+++ b/src/view/frontend/layout/sales_email_order_creditmemo_items.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd" label="Email Creditmemo Items List" design_abstraction="custom">
+    <body>
+        <referenceBlock name="additional.product.info">
+            <block name="additional.product.info.packs" template="Nanobots_ProductPack::sales/item/additional/info.phtml">
+                <arguments>
+                    <argument name="viewModel" xsi:type="object">Nanobots\ProductPack\ViewModel\Product\Pack</argument>
+                </arguments>
+            </block>
+        </referenceBlock>
+    </body>
+</page>

--- a/src/view/frontend/layout/sales_email_order_invoice_items.xml
+++ b/src/view/frontend/layout/sales_email_order_invoice_items.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="additional.product.info">
+            <block name="additional.product.info.packs" template="Nanobots_ProductPack::sales/item/additional/info.phtml">
+                <arguments>
+                    <argument name="viewModel" xsi:type="object">Nanobots\ProductPack\ViewModel\Product\Pack</argument>
+                </arguments>
+            </block>
+        </referenceBlock>
+    </body>
+</page>

--- a/src/view/frontend/layout/sales_email_order_items.xml
+++ b/src/view/frontend/layout/sales_email_order_items.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="additional.product.info">
+            <block name="additional.product.info.packs" template="Nanobots_ProductPack::sales/item/additional/info.phtml">
+                <arguments>
+                    <argument name="viewModel" xsi:type="object">Nanobots\ProductPack\ViewModel\Product\Pack</argument>
+                </arguments>
+            </block>
+        </referenceBlock>
+    </body>
+</page>

--- a/src/view/frontend/layout/sales_email_order_shipment_items.xml
+++ b/src/view/frontend/layout/sales_email_order_shipment_items.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd" label="Email Shipment Items List" design_abstraction="custom">
+    <body>
+        <referenceBlock name="additional.product.info">
+            <block name="additional.product.info.packs" template="Nanobots_ProductPack::sales/item/additional/info.phtml">
+                <arguments>
+                    <argument name="viewModel" xsi:type="object">Nanobots\ProductPack\ViewModel\Product\Pack</argument>
+                </arguments>
+            </block>
+        </referenceBlock>
+    </body>
+</page>

--- a/src/view/frontend/layout/sales_order_item_renderers.xml
+++ b/src/view/frontend/layout/sales_order_item_renderers.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Hyvä Themes - https://hyva.io
+ * Copyright © Hyvä Themes 2020-present. All rights reserved.
+ * This product is licensed per Magento install
+ * See https://hyva.io/license
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="additional.product.info">
+            <block name="additional.product.info.packs" template="Nanobots_ProductPack::sales/item/additional/info.phtml">
+                <arguments>
+                    <argument name="viewModel" xsi:type="object">Nanobots\ProductPack\ViewModel\Product\Pack</argument>
+                </arguments>
+            </block>
+        </referenceBlock>
+    </body>
+</page>

--- a/src/view/frontend/templates/sales/item/additional/info.phtml
+++ b/src/view/frontend/templates/sales/item/additional/info.phtml
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright © Q-Solutions Studio: eCommerce Nanobots. All rights reserved.
+ *
+ * @category    Nanobots
+ * @package     Nanobots_ProductPack
+ * @author      Jakub Winkler <jwinkler@qsolutionsstudio.com>
+ * @author      Wojtek Wnuk <wojtek@qsolutionsstudio.com>
+ * @author      Łukasz Owczarczuk <lukasz@qsolutionsstudio.com>
+ */
+
+use Nanobots\ProductPack\Model\Product\Type\Pack as PackType;
+use Nanobots\ProductPack\ViewModel\Product\Pack;
+use Magento\Framework\View\Element\Template;
+use Magento\Quote\Model\Quote\Item;
+
+/** @var Template $block */
+/** @var Pack $viewModel */
+/** @var Item $item */
+$item = $block->getParentBlock()->getData('item');
+?>
+<?php if ($item->getProduct()->getTypeId() === PackType::TYPE_CODE): ?>
+    <?php
+        $viewModel = $block->getData('viewModel');
+        $buyRequest = $item->getBuyRequest();
+        $packOption = $buyRequest->getData('pack_option');
+
+        // check null param for multi cart data
+        if ($packOption === null) {
+            $itemOptions = $viewModel->getProductItemOptions((int)$item->getId());
+            foreach ($itemOptions as $itemOption) {
+                if ($itemOption->getCode() === "info_buyRequest") {
+                    $buyRequest = json_decode($itemOption->getValue(), true);
+                    if ($buyRequest) {
+                        $packOption = $buyRequest['pack_option'];
+                    }
+                }
+            }
+        }
+
+        $title = $packOption['title'] ?? '';
+        $qty = $packOption['pack_size'] ?? '';
+    ?>
+    <?php if ((int)$qty > 1): ?>
+    <div class="pack-options-container">
+        <div class="pack-option-title">
+            <span><?= __('Package') ?>:&nbsp;<strong><?= __($title) ?></strong></span>
+        </div>
+        <div class="pack-option-qty">
+            <span><?= __('Units') ?>:&nbsp;</span><strong><?= $qty
+                ?></strong>
+        </div>
+    </div>
+    <?php endif ?>
+<?php endif; ?>


### PR DESCRIPTION
Add in Additional Product Info for line items with packs to:

Admin:

1. Order view
2. Invoice view/new
3. Credit Memo view/new
4. Shipping

Emails for all of above in admin / frontend
