### PR TITLE
Add feature to display calculated price on PDP when option is selected

### DIFF
--- a/src/Helper/Price.php
+++ b/src/Helper/Price.php
@@ -97,7 +97,7 @@ class Price extends AbstractHelper
      * @param float|null $specialPrice
      * @return array
      */
-    public function calculatePrices($basePrice, $price, $discountType, $discountValue, ?float $specialPrice = 0.00, $packQty = 0): array
+    public function calculatePrices($basePrice, $price, $discountType, $discountValue, ?float $specialPrice = 0.00, $packQty = 1): array
     {
         if ($specialPrice) {
             return [

--- a/src/Model/Product/Price.php
+++ b/src/Model/Product/Price.php
@@ -31,6 +31,7 @@ use Magento\Store\Model\StoreManagerInterface;
 class Price extends PriceModel
 {
     const XPATH_PRODUCT_PACK_CONFIG_SPECIAL_PRICE = 'product_pack/settings/special_price_calc';
+
     /**
      * @var Json|mixed
      */

--- a/src/ViewModel/Product/Pack.php
+++ b/src/ViewModel/Product/Pack.php
@@ -315,4 +315,5 @@ class Pack implements ArgumentInterface
         $collection->addFieldToFilter('item_id', ['eq' => $itemId]);
         return $collection;
     }
+    
 }

--- a/src/etc/adminhtml/system.xml
+++ b/src/etc/adminhtml/system.xml
@@ -28,6 +28,11 @@
                     <source_model>Nanobots\ProductPack\Model\Config\Source\SpecialPriceCalculationType</source_model>
                     <comment><![CDATA[What price should be used for single unit in a pack if special price is enabled]]></comment>
                 </field>
+
+                <field id="pdp_display_calculated_price" type="select" sortOrder="10" showInWebsite="1" showInStore="1" showInDefault="1" translate="label">
+                    <label>Display full price in Product View (price * pack qty)</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
             </group>
         </section>
     </system>

--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -17,6 +17,7 @@
             <settings>
                 <option_display_type>price</option_display_type>
                 <special_price_calc>min</special_price_calc>
+                <pdp_display_calculated_price>0</pdp_display_calculated_price>
             </settings>
         </product_pack>
     </default>

--- a/src/view/frontend/templates/product/view/type/options/hyva_pack.phtml
+++ b/src/view/frontend/templates/product/view/type/options/hyva_pack.phtml
@@ -52,11 +52,19 @@ $helper = $this->helper(PriceHelper::class);
                 this.packOptions.value = this.packOptionSelected;
                 this.pack_option_hash = btoa(JSON.stringify(this.packOptions));
                 let data = this.packOptionPrices[this.packOptionSelected];
-                if (data.hasOwnProperty('price')) {
-                    let mainPriceElm = document.querySelector('.final-price #product-price-' + this.product_id + ' .price');
-                    if (mainPriceElm) {
+                let mainPriceElm = document.querySelector('.final-price #product-price-' + this.product_id + ' .price');
+                if (mainPriceElm) {
+                    <?php  if ($helper->displayCalculatedPrice()): ?>
+                    if (data.hasOwnProperty('qty_price')) {
+                        mainPriceElm.textContent = data.qty_price;
+                    } else if (data.hasOwnProperty('price')) {
                         mainPriceElm.textContent = data.price;
                     }
+                    <?php else : ?>
+                    if (data.hasOwnProperty('price')) {
+                        mainPriceElm.textContent = data.price;
+                    }
+                    <?php endif ?>
                 }
                 if (data.hasOwnProperty('base_price')) {
                     let priceElm = document.querySelector('#price-including-tax-product-price-' + this.product_id + ' > .price');

--- a/src/view/frontend/templates/product/view/type/options/pack.phtml
+++ b/src/view/frontend/templates/product/view/type/options/pack.phtml
@@ -72,7 +72,8 @@ $helper = $this->helper(PriceHelper::class);
         "#product_addtocart_form": {
             "productpack": {
                 "packPrices": <?= $helper->getPriceConfigJson($viewModel->getProduct()) ?>,
-                "productId": "<?= $viewModel->getProduct()->getId(); ?>"
+                "productId": "<?= $viewModel->getProduct()->getId(); ?>",
+                "display_calculated_price": <?= $helper->displayCalculatedPrice(true) ?>
             }
         }
     }

--- a/src/view/frontend/web/js/productpack.js
+++ b/src/view/frontend/web/js/productpack.js
@@ -70,7 +70,6 @@ define([
                 $('input[name="pack_option_hash"]').val(btoa(JSON.stringify(packOptionHashData)));
 
                 let data = this.options.packPrices[checkedOptionVal];
-                debugger;
                 if (data.hasOwnProperty('price')) {
                     var priceDisplay = data.price;
                     if( this.options.display_calculated_price ) {

--- a/src/view/frontend/web/js/productpack.js
+++ b/src/view/frontend/web/js/productpack.js
@@ -23,7 +23,8 @@ define([
     $.widget('nanobots.productpack', {
         options: {
             packPrices: {},
-            productId: null
+            productId: null,
+            display_calculated_price: false,
         },
 
         /**
@@ -69,9 +70,15 @@ define([
                 $('input[name="pack_option_hash"]').val(btoa(JSON.stringify(packOptionHashData)));
 
                 let data = this.options.packPrices[checkedOptionVal];
-
+                debugger;
                 if (data.hasOwnProperty('price')) {
-                    $('.price-wrapper  > .price').text(data.price);
+                    var priceDisplay = data.price;
+                    if( this.options.display_calculated_price ) {
+                        if (data.hasOwnProperty('qty_price')) {
+                            priceDisplay = data.qty_price;
+                        }
+                    }
+                    $('.price-wrapper  > .price').text(priceDisplay);
                 }
                 if (data.hasOwnProperty('base_price')) {
                     $('#price-excluding-tax-product-price-'+productId + ' > .price').text(data.base_price);


### PR DESCRIPTION
On PDP, when an option is selected, only the pack unit price is displayed. So, when added to cart, it is not a realistic view of the outcome of price * pack qty

example: 
![image](https://github.com/enanobots/m2-product-pack/assets/4994260/6d8b98bc-669a-40d0-9222-fdf66be47e7f)
added to cart
![image](https://github.com/enanobots/m2-product-pack/assets/4994260/8fddae85-5eb2-469b-b311-9629794b8b80)

This proposed change adds in an option in admin to set the proper price (pack qty * unit price) on the PDP page when a pack is selected, which then reflects the price that will be in cart (same same)

![image](https://github.com/enanobots/m2-product-pack/assets/4994260/2e240048-dcbc-4ad3-8422-0c92ae7e1162)

![image](https://github.com/enanobots/m2-product-pack/assets/4994260/916a3753-2b70-4bee-bf1a-2aaf1674f7df)

This has been added as an option so as to allow backwards compatibility with existing deploys.

Works on Hyva theme as well.
